### PR TITLE
fix: 쿠키 기반 refresh token 브라우저 호환성 개선

### DIFF
--- a/src/main/java/sh4re_v2/sh4re_v2/config/CorsConfig.java
+++ b/src/main/java/sh4re_v2/sh4re_v2/config/CorsConfig.java
@@ -16,8 +16,8 @@ public class CorsConfig {
     config.setAllowCredentials(true);
     config.setAllowedOrigins(List.of("http://localhost:5173", "http://localhost:4173", "https://sh4re2.chaeyn.com"));
     config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-    config.setExposedHeaders(List.of("Authorization","Content-Type", "Accept"));
-    config.setAllowedHeaders(List.of("Authorization","Content-Type", "Accept"));
+    config.setExposedHeaders(List.of("Authorization","Content-Type", "Accept", "Set-Cookie"));
+    config.setAllowedHeaders(List.of("Authorization","Content-Type", "Accept", "Cookie"));
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", config);

--- a/src/main/java/sh4re_v2/sh4re_v2/config/SecurityConfig.java
+++ b/src/main/java/sh4re_v2/sh4re_v2/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.web.cors.CorsConfigurationSource;
 import sh4re_v2.sh4re_v2.config.SecurityPathConfig.EndpointConfig;
 import sh4re_v2.sh4re_v2.security.AuthorityChecker;
 import sh4re_v2.sh4re_v2.security.CustomAccessDeniedHandler;
@@ -30,10 +31,12 @@ public class SecurityConfig {
   private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
   private final CustomAccessDeniedHandler accessDeniedHandler;
+  private final CorsConfigurationSource corsConfigurationSource;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
+        .cors(cors -> cors.configurationSource(corsConfigurationSource))
         .csrf(AbstractHttpConfigurer::disable)
         .exceptionHandling(exception -> exception
             .authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/java/sh4re_v2/sh4re_v2/security/Jwt/JwtTokenProvider.java
+++ b/src/main/java/sh4re_v2/sh4re_v2/security/Jwt/JwtTokenProvider.java
@@ -150,11 +150,17 @@ public class JwtTokenProvider {
 
   public String getRefreshTokenFromRequest(HttpServletRequest request) {
     String refreshToken = null;
-    for (Cookie cookie : request.getCookies()) {
-      if (cookie.getName().equals("refreshToken")) {
-        refreshToken = cookie.getValue();
+    Cookie[] cookies = request.getCookies();
+    
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (cookie.getName().equals("refreshToken")) {
+          refreshToken = cookie.getValue();
+          break;
+        }
       }
     }
+    
     if(refreshToken == null) throw AuthException.of(AuthStatusCode.INVALID_JWT);
     return refreshToken;
   }

--- a/src/main/java/sh4re_v2/sh4re_v2/service/main/AuthService.java
+++ b/src/main/java/sh4re_v2/sh4re_v2/service/main/AuthService.java
@@ -44,15 +44,20 @@ public class AuthService {
   private final ClassPlacementService classPlacementService;
   @Value("${cookie.domain:localhost}")
   private String COOKIE_DOMAIN;
+  @Value("${cookie.secure:false}")
+  private boolean COOKIE_SECURE;
+  @Value("${cookie.same-site:Lax}")
+  private String COOKIE_SAME_SITE;
   private static final String COOKIE_PATH = "/";
   private static final int COOKIE_MAX_AGE = 60 * 60 * 60 * 24 * 30;
 
-  private Cookie createCookie(String name, String value, boolean isSecure) {
+  private Cookie createCookie(String name, String value) {
     Cookie cookie = new Cookie(name, value);
     cookie.setDomain(COOKIE_DOMAIN);
     cookie.setPath(COOKIE_PATH);
     cookie.setMaxAge(COOKIE_MAX_AGE);
-    cookie.setSecure(isSecure);
+    cookie.setSecure(COOKIE_SECURE);
+    cookie.setHttpOnly(true);
     return cookie;
   }
 
@@ -80,7 +85,7 @@ public class AuthService {
     refreshTokenService.saveOrUpdateRefreshToken(user.getUsername(), refreshToken);
 
     // 쿠키 설정
-    Cookie refreshCookie = createCookie("refreshToken", refreshToken, true);
+    Cookie refreshCookie = createCookie("refreshToken", refreshToken);
     response.addCookie(refreshCookie);
 
     // 응답 객체 생성 및 반환
@@ -135,7 +140,7 @@ public class AuthService {
 
     // 4. 새 Refresh Token 발급 & 쿠키에 저장
     String newRefreshToken = jwtTokenProvider.generateNewRefreshToken(user);
-    response.addCookie(createCookie("refreshToken", newRefreshToken, true));
+    response.addCookie(createCookie("refreshToken", newRefreshToken));
 
     return new RefreshTokenRes(newAccessToken);
   }


### PR DESCRIPTION
## 브라우저에서 refresh token 쿠키가 자동 삽입되지 않는 문제를 해결하기 위해 CORS 및 쿠키 설정을 개선했습니다.

## 변경사항

CORS 설정 개선

- Set-Cookie와 Cookie 헤더를 허용 CORS 설정 업데이트
- SecurityConfig에서 CORS 설정 명시적 활성화

쿠키 보안 설정 강화

- 환경별 쿠키 보안 설정 분리
- HttpOnly 속성 추가
- SameSite 설정 준비

Null 안전성 개선

- JwtTokenProvider에서 쿠키 배열 null 체크 추가

---

- 개발 환경: HTTP에서 쿠키 사용 가능 (COOKIE_SECURE=false)
- 배포 환경: HTTPS에서만 쿠키 사용 (COOKIE_SECURE=true)
- 도메인별 설정: COOKIE_DOMAIN 환경변수로 도메인 관리

### .env 파일 설정 확인

#### 개발용

COOKIE_SECURE=false
COOKIE_DOMAIN=localhost

#### 배포용

COOKIE_SECURE=true
COOKIE_DOMAIN=sh4redomain.com